### PR TITLE
Fix: remove git merge conflict marker from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,4 +96,3 @@ All rights reserved © 2025 Jeffrey Kerr
 **Built with passion and attention to detail** 🎵
 
 *This website represents Jeffrey Kerr's professional online presence, designed to showcase skills, experience, and projects in a clean, modern format.*
->>>>>>> 0505292ca102fb18ce47b521ccd9b646f6536c40


### PR DESCRIPTION
Found and fixed a leftover git merge conflict marker in README.md that was causing Netlify deployment initialization failure. This type of merge conflict remnant can prevent proper git operations during deployment.

₍ᐢ•(ܫ)•ᐢ₎ Generated by [Scout](https://scout.new) ([view task](https://scout.new/project/5721dc26-84af-11f0-a94e-3eef481a796b/task/43114dec-cdf2-4294-a5d7-d8ee96b3f302))